### PR TITLE
Revert "chore(container): update ghcr.io/kashalls/external-dns-unifi-webhook ( 31e3f1d → ee95cf2 )"

### DIFF
--- a/kubernetes/main/apps/networking/external-dns/unifi/helmrelease.yaml
+++ b/kubernetes/main/apps/networking/external-dns/unifi/helmrelease.yaml
@@ -30,7 +30,7 @@ spec:
       webhook:
         image:
           repository: ghcr.io/kashalls/external-dns-unifi-webhook
-          tag: main@sha256:ee95cf2b88b72aeb00690e140ca3e966662d1cc8e415e6fe2f7c24a8c9b81ac4
+          tag: main@sha256:31e3f1d561ae2c56e9711376940e6ced1fff9e5a6339567bdaf109afd0351cc2
         env:
           - name: UNIFI_HOST
             value: https://10.1.1.1


### PR DESCRIPTION
Reverts rodent1/home-ops#1540