### PR TITLE
Revert "fix(container): update ghcr.io/kashalls/external-dns-unifi-webhook (v0.3.0 → v0.3.1)"

### DIFF
--- a/kubernetes/main/apps/networking/external-dns/unifi/helmrelease.yaml
+++ b/kubernetes/main/apps/networking/external-dns/unifi/helmrelease.yaml
@@ -30,7 +30,7 @@ spec:
       webhook:
         image:
           repository: ghcr.io/kashalls/external-dns-unifi-webhook
-          tag: v0.3.1@sha256:593eeb3594a8418084d3235b2a30ca8aa4c58b949fac3433b86df6c725364e32
+          tag: v0.3.0@sha256:1d898f10f894c784f4516c7188d92cf928f7f03e8010fa83b9384eb569164cc1
         env:
           - name: UNIFI_HOST
             value: https://10.1.1.1


### PR DESCRIPTION
Reverts rodent1/home-ops#2130