### PR TITLE
Snapshot-fix

### DIFF
--- a/kubernetes/main/apps/volsync-system/snapshot-controller/app/helmrelease.yaml
+++ b/kubernetes/main/apps/volsync-system/snapshot-controller/app/helmrelease.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: snapshot-controller
-      version: 4.0.0
+      version: 3.0.6
       sourceRef:
         kind: HelmRepository
         name: piraeus
@@ -29,3 +29,5 @@ spec:
       replicaCount: 2
       serviceMonitor:
         create: true
+    webhook:
+      enabled: false


### PR DESCRIPTION
From onedr0p: So the snapshot-controller v4 update doesn't work with rook-ceph due the group CRDs going from v1alpha1 to v1beta1

To revert:

`k delete crd volumegroupsnapshotclasses.groupsnapshot.storage.k8s.io volumegroupsnapshotcontents.groupsnapshot.storage.k8s.io volumegroupsnapshots.groupsnapshot.storage.k8s.io`

then commit the old version back to 3.0.6