### PR TITLE
Revert "Update image docker.io/getmeili/meilisearch (v1.50.0 ➔ v1.51.0)"

### DIFF
--- a/kubernetes/apps/selfhosted/karakeep/app/helmrelease.yaml
+++ b/kubernetes/apps/selfhosted/karakeep/app/helmrelease.yaml
@@ -71,7 +71,7 @@ spec:
           app:
             image:
               repository: docker.io/getmeili/meilisearch
-              tag: v1.51.0
+              tag: v1.50.0
             args:
               - /bin/meilisearch
               - --experimental-dumpless-upgrade


### PR DESCRIPTION
Reverts rodent1/home-ops#4925