### PR TITLE
feat: deploy Ocharted OCI proxy

### DIFF
--- a/.github/workflows/image-pull.yaml
+++ b/.github/workflows/image-pull.yaml
@@ -28,10 +28,14 @@ jobs:
           patterns: kubernetes/**/*
 
   extract:
-    if: ${{ needs.filter.outputs.changed-files != '[]' }}
+    if: >-
+      ${{
+        needs.filter.outputs.changed-files != '[]' &&
+        github.event.pull_request.head.repo.full_name == github.repository
+      }}
     needs: filter
     name: Image Pull - Extract Images
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.event.repository.name }}-runner
     outputs:
       images: ${{ steps.extract.outputs.images }}
     steps:

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -52,6 +52,8 @@ jobs:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           GITHUB_BOT_APP_CLIENT_ID: op://home-ops/github-bot/GITHUB_BOT_APP_CLIENT_ID
           GITHUB_BOT_APP_PRIVATE_KEY: op://home-ops/github-bot/GITHUB_BOT_APP_PRIVATE_KEY
+          OCHARTED_USERNAME: op://home-ops/ocharted/OCHARTED_USERNAME
+          OCHARTED_PASSWORD: op://home-ops/ocharted/OCHARTED_PASSWORD
 
       - name: Generate Token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
@@ -83,6 +85,11 @@ jobs:
           RENOVATE_INTERNAL_CHECKS_FILTER: strict
           RENOVATE_PLATFORM: github
           RENOVATE_PLATFORM_COMMIT: true
+          RENOVATE_SECRETS: |-
+            {
+              "OCHARTED_USERNAME": "${{ steps.load-secrets.outputs.OCHARTED_USERNAME }}",
+              "OCHARTED_PASSWORD": "${{ steps.load-secrets.outputs.OCHARTED_PASSWORD }}"
+            }
         with:
           token: ${{ steps.app-token.outputs.token }}
           renovate-version: ${{ inputs.version || 'latest' }}

--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -1,6 +1,15 @@
 {
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
   extends: ["github>home-operations/renovate-presets#3.0.0", ":timezone(Europe/Oslo)"],
+  hostRules: [
+    {
+      description: "Authenticate against the Ocharted OCI registry",
+      matchHost: "ocharted.rodent.cc",
+      hostType: "docker",
+      username: "{{ secrets.OCHARTED_USERNAME }}",
+      password: "{{ secrets.OCHARTED_PASSWORD }}",
+    },
+  ],
   packageRules: [
     // Auto-merge rules
     {

--- a/kubernetes/apps/kube-system/descheduler/app/ocirepository.yaml
+++ b/kubernetes/apps/kube-system/descheduler/app/ocirepository.yaml
@@ -11,4 +11,4 @@ spec:
     operation: copy
   ref:
     tag: 0.36.0
-  url: oci://ghcr.io/home-operations/charts-mirror/descheduler
+  url: oci://ocharted.rodent.cc/kubernetes-sigs.github.io/descheduler/descheduler

--- a/kubernetes/apps/kube-system/kustomization.yaml
+++ b/kubernetes/apps/kube-system/kustomization.yaml
@@ -14,6 +14,7 @@ resources:
   - ./descheduler/ks.yaml
   - ./intel-gpu-resource-driver/ks.yaml
   - ./metrics-server/ks.yaml
+  - ./ocharted/ks.yaml
   - ./reloader/ks.yaml
   - ./snapshot-controller/ks.yaml
   - ./spegel/ks.yaml

--- a/kubernetes/apps/kube-system/metrics-server/app/ocirepository.yaml
+++ b/kubernetes/apps/kube-system/metrics-server/app/ocirepository.yaml
@@ -11,4 +11,4 @@ spec:
     operation: copy
   ref:
     tag: 3.13.1
-  url: oci://ghcr.io/home-operations/charts-mirror/metrics-server
+  url: oci://ocharted.rodent.cc/kubernetes-sigs.github.io/metrics-server/metrics-server

--- a/kubernetes/apps/kube-system/ocharted/app/externalsecret.yaml
+++ b/kubernetes/apps/kube-system/ocharted/app/externalsecret.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: ocharted
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: ocharted-secret
+    template:
+      data:
+        auth: "{{ .OCHARTED_USERNAME }}:{{ .OCHARTED_PASSWORD }}"
+  dataFrom:
+    - extract:
+        key: ocharted

--- a/kubernetes/apps/kube-system/ocharted/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/ocharted/app/helmrelease.yaml
@@ -1,0 +1,44 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: ocharted
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: ocharted
+  interval: 1h
+  values:
+    replicaCount: 2
+    config:
+      upstreamAllowlist:
+        - ceph.github.io
+        - kubernetes-sigs.github.io
+    auth:
+      existingSecret: ocharted-secret
+      bypassNetworks:
+        - 10.42.0.0/16
+    deploymentAnnotations:
+      reloader.stakater.com/auto: "true"
+    httpRoute:
+      enabled: true
+      annotations:
+        gatus.home-operations.com/endpoint: |-
+          path: /healthz
+          conditions: ["[STATUS] == 200"]
+      hostnames:
+        - ocharted.rodent.cc
+      parentRefs:
+        - name: envoy-external
+          namespace: network
+    monitoring:
+      serviceMonitor:
+        enabled: true
+    podDisruptionBudget:
+      enabled: true
+    resources:
+      requests:
+        cpu: 10m
+      limits:
+        memory: 512Mi

--- a/kubernetes/apps/kube-system/ocharted/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/ocharted/app/helmrelease.yaml
@@ -11,10 +11,8 @@ spec:
   interval: 1h
   values:
     replicaCount: 2
-    config:
-      upstreamAllowlist:
-        - ceph.github.io
-        - kubernetes-sigs.github.io
+    podDisruptionBudget:
+      enabled: true
     auth:
       existingSecret: ocharted-secret
       bypassNetworks:
@@ -28,15 +26,13 @@ spec:
           path: /healthz
           conditions: ["[STATUS] == 200"]
       hostnames:
-        - ocharted.rodent.cc
+        - "{{ .Release.Name }}.rodent.cc"
       parentRefs:
         - name: envoy-external
           namespace: network
     monitoring:
       serviceMonitor:
         enabled: true
-    podDisruptionBudget:
-      enabled: true
     resources:
       requests:
         cpu: 10m

--- a/kubernetes/apps/kube-system/ocharted/app/kustomization.yaml
+++ b/kubernetes/apps/kube-system/ocharted/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/kube-system/ocharted/app/ocirepository.yaml
+++ b/kubernetes/apps/kube-system/ocharted/app/ocirepository.yaml
@@ -3,12 +3,12 @@
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: OCIRepository
 metadata:
-  name: unifi-dns
+  name: ocharted
 spec:
   interval: 15m
   layerSelector:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 1.21.1
-  url: oci://ocharted.rodent.cc/kubernetes-sigs.github.io/external-dns/external-dns
+    tag: 0.1.3
+  url: oci://ghcr.io/home-operations/charts/ocharted

--- a/kubernetes/apps/kube-system/ocharted/ks.yaml
+++ b/kubernetes/apps/kube-system/ocharted/ks.yaml
@@ -1,0 +1,16 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: ocharted
+spec:
+  interval: 1h
+  path: ./kubernetes/apps/kube-system/ocharted/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: kube-system
+  wait: false

--- a/kubernetes/apps/network/cloudflare-dns/app/ocirepository.yaml
+++ b/kubernetes/apps/network/cloudflare-dns/app/ocirepository.yaml
@@ -11,4 +11,4 @@ spec:
     operation: copy
   ref:
     tag: 1.21.1
-  url: oci://ghcr.io/home-operations/charts-mirror/external-dns
+  url: oci://ocharted.rodent.cc/kubernetes-sigs.github.io/external-dns/external-dns

--- a/kubernetes/apps/rook-ceph/ceph-csi-drivers/app/ocirepository.yaml
+++ b/kubernetes/apps/rook-ceph/ceph-csi-drivers/app/ocirepository.yaml
@@ -11,4 +11,4 @@ spec:
     operation: copy
   ref:
     tag: 1.0.4
-  url: oci://ghcr.io/home-operations/charts-mirror/ceph-csi-drivers
+  url: oci://ocharted.rodent.cc/ceph.github.io/ceph-csi-operator/ceph-csi-drivers


### PR DESCRIPTION
## Summary

- deploy two Ocharted replicas behind `ocharted.rodent.cc`
- restrict upstream chart sources to Kubernetes SIGs and Ceph
- authenticate external callers while bypassing the pod CIDR
- migrate descheduler, metrics-server, external-dns, and ceph-csi-drivers away from the static charts mirror
- teach Renovate to authenticate to Ocharted
- move the image extraction job onto the repository runner, with a same-repository guard for fork PRs

## Before merging

Create an `ocharted` item in the `home-ops` 1Password vault with:

- `OCHARTED_USERNAME`
- `OCHARTED_PASSWORD`

The ExternalSecret and Renovate workflow both consume those exact fields.

## Validation

- complete kube-system and Ocharted Kustomize renders
- published Ocharted 0.1.3 Helm chart render
- OCI source paths checked against their upstream repositories
- `actionlint`, `zizmor`, formatting, and repository pre-commit hooks
