### PR TITLE
feat(talos): add native BGP API anycast

### DIFF
--- a/kubernetes/apps/kube-system/cilium/app/networking.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/networking.yaml
@@ -32,6 +32,9 @@ kind: CiliumBGPPeerConfig
 metadata:
   name: l3-bgp-peer-config
 spec:
+  timers:
+    holdTimeSeconds: 9
+    keepAliveTimeSeconds: 3
   families:
     - afi: ipv4
       safi: unicast

--- a/talos/ANYCAST.md
+++ b/talos/ANYCAST.md
@@ -1,0 +1,89 @@
+# Talos-native Kubernetes API anycast
+
+This design adds a Cilium-independent Kubernetes API endpoint advertised by
+the Talos 1.14 native BGP speaker on the three control-plane nodes.
+
+It is intentionally staged as a draft. Do not apply these machine configs
+until Talos 1.14 is deployed and the proposed network allocation has been
+confirmed on the UniFi gateway and switch ports.
+
+## Proposed allocation
+
+| Purpose             | Value                    |
+| ------------------- | ------------------------ |
+| API anycast address | `10.1.66.1/32`           |
+| BGP peering VLAN    | VLAN 67, `10.1.67.0/24`  |
+| UniFi gateway peer  | `10.1.67.1`, ASN `64513` |
+| Talos host ASN      | `64515`                  |
+| Control-plane peers | `10.1.67.31-33`          |
+
+The anycast address is outside the node subnet and the Cilium load-balancer
+pool. If BGP is unavailable, it becomes cleanly unreachable instead of falling
+back to ARP on a connected network.
+
+The existing `10.1.1.30` Talos Layer2 VIP and Cilium `kube-api` Service remain
+unchanged. DNS must not move to `10.1.66.1` until the new route has been tested
+from every client network.
+
+## UniFi FRR configuration
+
+Merge the Talos peer group into the existing Cilium BGP configuration. UniFi
+accepts one BGP configuration per device, so uploading this replaces the
+current configuration and briefly resets the existing sessions.
+
+```text
+router bgp 64513
+  bgp router-id 10.1.1.1
+  no bgp ebgp-requires-policy
+
+  neighbor k8s peer-group
+  neighbor k8s remote-as 64514
+  neighbor 10.1.1.31 peer-group k8s
+  neighbor 10.1.1.32 peer-group k8s
+  neighbor 10.1.1.33 peer-group k8s
+  neighbor 10.1.1.34 peer-group k8s
+  neighbor 10.1.1.35 peer-group k8s
+
+  neighbor k8s-host peer-group
+  neighbor k8s-host remote-as 64515
+  neighbor 10.1.67.31 peer-group k8s-host
+  neighbor 10.1.67.32 peer-group k8s-host
+  neighbor 10.1.67.33 peer-group k8s-host
+
+  address-family ipv4 unicast
+    maximum-paths 3
+    neighbor k8s next-hop-self
+    neighbor k8s soft-reconfiguration inbound
+    neighbor k8s-host next-hop-self
+    neighbor k8s-host soft-reconfiguration inbound
+  exit-address-family
+exit
+```
+
+## Why policy routing is required
+
+Traffic enters through VLAN 67. Replies sourced from `10.1.66.1` must return
+through the same gateway so stateful firewall and conntrack paths remain
+symmetric. Routing rule 100 sends anycast-sourced replies through table 100,
+whose default route is `10.1.67.1` on each node.
+
+## Rollout
+
+1. Upgrade Talos and `talosctl` to 1.14 or newer.
+2. Confirm that VLAN 67 and all proposed addresses are unused.
+3. Create/tag VLAN 67 on the gateway and the three control-plane switch ports.
+4. Replace the UniFi FRR configuration with the merged configuration above.
+5. Apply the Talos config one control-plane node at a time.
+6. Confirm all three BGP sessions and all three ECMP paths for `10.1.66.1/32`.
+7. Test repeated TLS and authenticated Kubernetes API requests from every VLAN.
+8. Only then consider changing `k8s.internal` to `10.1.66.1`.
+
+Graceful shutdown withdraws the route immediately. The negotiated 9-second
+hold time limits stale routes after a hard failure; the 3-second Cilium
+keepalive applies the same failure-detection policy to Service VIP routes.
+
+## Rollback
+
+Keep `k8s.internal` on `10.1.1.30` during rollout. If validation fails, remove
+the Talos host peer group from FRR and revert these machine-config documents;
+the existing Layer2 VIP and Cilium Service continue to provide the API path.

--- a/talos/machineconfig.yaml.j2
+++ b/talos/machineconfig.yaml.j2
@@ -125,6 +125,7 @@ cluster:
         - level: Metadata
     certSANs:
       - k8s.internal
+      - 10.1.66.1
     disablePodSecurityPolicy: true
     extraArgs:
       enable-aggregator-routing: "true"
@@ -178,3 +179,29 @@ apiVersion: v1alpha1
 kind: WatchdogTimerConfig
 device: /dev/watchdog0
 timeout: 5m
+{% if ENV.CONTROLPLANE %}
+---
+# Talos 1.14+ only. See talos/ANYCAST.md before applying.
+apiVersion: v1alpha1
+kind: DummyLinkConfig
+name: dummy0
+addresses:
+  - address: 10.1.66.1/32
+---
+apiVersion: v1alpha1
+kind: RoutingRuleConfig
+name: "100"
+src: 10.1.66.1/32
+table: 100
+---
+apiVersion: v1alpha1
+kind: BGPInstanceConfig
+name: main
+localASN: 64515
+advertise:
+  - dummy0
+neighbors:
+  - address: 10.1.67.1
+    peerASN: 64513
+    holdTime: 9s
+{% endif %}

--- a/talos/nodes/node-1.yaml.j2
+++ b/talos/nodes/node-1.yaml.j2
@@ -31,3 +31,20 @@ apiVersion: v1alpha1
 kind: Layer2VIPConfig
 name: 10.1.1.30
 link: net0
+---
+apiVersion: v1alpha1
+kind: VLANConfig
+name: net0.67
+vlanID: 67
+parent: net0
+mtu: 9000
+addresses:
+  - address: 10.1.67.31/24
+routes:
+  - gateway: 10.1.67.1
+    table: 100
+---
+apiVersion: v1alpha1
+kind: BGPInstanceConfig
+name: main
+routerID: 10.1.67.31

--- a/talos/nodes/node-2.yaml.j2
+++ b/talos/nodes/node-2.yaml.j2
@@ -31,3 +31,20 @@ apiVersion: v1alpha1
 kind: Layer2VIPConfig
 name: 10.1.1.30
 link: net0
+---
+apiVersion: v1alpha1
+kind: VLANConfig
+name: net0.67
+vlanID: 67
+parent: net0
+mtu: 9000
+addresses:
+  - address: 10.1.67.32/24
+routes:
+  - gateway: 10.1.67.1
+    table: 100
+---
+apiVersion: v1alpha1
+kind: BGPInstanceConfig
+name: main
+routerID: 10.1.67.32

--- a/talos/nodes/node-3.yaml.j2
+++ b/talos/nodes/node-3.yaml.j2
@@ -31,3 +31,20 @@ apiVersion: v1alpha1
 kind: Layer2VIPConfig
 name: 10.1.1.30
 link: net0
+---
+apiVersion: v1alpha1
+kind: VLANConfig
+name: net0.67
+vlanID: 67
+parent: net0
+mtu: 9000
+addresses:
+  - address: 10.1.67.33/24
+routes:
+  - gateway: 10.1.67.1
+    table: 100
+---
+apiVersion: v1alpha1
+kind: BGPInstanceConfig
+name: main
+routerID: 10.1.67.33


### PR DESCRIPTION
## Summary

- add a Talos-native anycast Kubernetes API endpoint on `10.1.66.1/32`
- peer each control-plane node with the gateway over proposed VLAN 67
- use source-policy routing so anycast replies remain symmetric
- add the API address to the certificate SANs
- align Cilium BGP failure-detection timers
- document the combined UniFi FRR configuration, rollout, validation, and rollback

## Hard gates

Do not merge or apply this until:

- Talos 1.14 is released and deployed; the current Talos 1.13 config parser cannot read `BGPInstanceConfig`
- VLAN 67, `10.1.66.1/32`, `10.1.67.0/24`, and ASNs 64513/64515 are confirmed free and appropriate
- the three control-plane switch ports can carry VLAN 67
- the merged FRR configuration is reviewed for the UniFi gateway

This deliberately preserves the current `10.1.1.30` Layer2 VIP and Cilium API Service. It does not change DNS, so the new path can be tested without risking the existing control-plane endpoint.

## Validation

- control-plane and worker template renders
- Cilium Kustomize render
- complete config accepted by `talosctl v1.14.0-beta.1 machineconfig patch`
- formatting and repository pre-commit hooks
