### PR TITLE
chore: harden core infrastructure defaults

### DIFF
--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/home-ops/helmrelease.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/home-ops/helmrelease.yaml
@@ -12,7 +12,7 @@ spec:
   values:
     githubConfigUrl: https://github.com/rodent1/home-ops
     githubConfigSecret: home-ops-runner-secret
-    minRunners: 1
+    minRunners: 0
     maxRunners: 3
     containerMode:
       type: kubernetes
@@ -27,7 +27,17 @@ spec:
       name: actions-runner-controller
       namespace: actions-runner-system
     template:
+      metadata:
+        labels:
+          runner: *name
       spec:
+        affinity:
+          podAntiAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              - labelSelector:
+                  matchLabels:
+                    runner: *name
+                topologyKey: kubernetes.io/hostname
         containers:
           - name: runner
             image: ghcr.io/home-operations/actions-runner:2.336.0@sha256:281a9a090522fafbf4967f158b8c97d03552b1978b688893c5f7cb1944bc5fe5

--- a/kubernetes/apps/kube-system/coredns/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/coredns/app/helmrelease.yaml
@@ -15,6 +15,7 @@ spec:
       repository: mirror.gcr.io/coredns/coredns
     replicaCount: 2
     k8sAppLabelOverride: kube-dns
+    priorityClassName: system-cluster-critical
     serviceAccount:
       create: true
     service:
@@ -45,6 +46,7 @@ spec:
             configBlock: |-
               prefetch 20
               serve_stale
+              servfail 0
           - name: loop
           - name: reload
           - name: loadbalance

--- a/kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml
@@ -58,7 +58,7 @@ spec:
         scrapeConfigSelectorNilUsesHelmValues: false
         serviceMonitorSelectorNilUsesHelmValues: false
         retention: 30d
-        retentionSize: 50GB
+        retentionSize: 40GiB
         resources:
           requests:
             cpu: 100m

--- a/talos/machineconfig.yaml.j2
+++ b/talos/machineconfig.yaml.j2
@@ -55,6 +55,10 @@ machine:
     defaultRuntimeSeccompProfileEnabled: true
     disableManifestsDirectory: true
     extraConfig:
+      crashLoopBackOff:
+        maxContainerRestartPeriod: 60s
+      imageMaximumGCAge: 168h
+      maxParallelImagePulls: 3
       serializeImagePulls: false
     image: ghcr.io/siderolabs/kubelet:v1.36.3
     nodeIP:


### PR DESCRIPTION
## Summary

- cap Prometheus retention by bytes using the correct binary unit
- tune Talos kubelet restart backoff, image age GC, and parallel pulls
- make CoreDNS cluster-critical and avoid caching SERVFAIL responses
- scale the repository runner to zero when idle and spread concurrent runners across nodes

## Validation

- YAML parsing and formatting checks
- `kubectl kustomize` for CoreDNS, Prometheus, and the runner
- complete Talos control-plane render and `talosctl machineconfig patch`
- repository pre-commit hooks

This intentionally does not suppress AAAA queries globally; that should remain a measured, evidence-driven change.
