### PR TITLE
Tune Kubernetes resource allocations

### DIFF
--- a/kubernetes/apps/database/cloudnative-pg/cluster/cluster.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/cluster/cluster.yaml
@@ -31,6 +31,7 @@ spec:
   resources:
     requests:
       cpu: 150m
+      memory: 512Mi
     limits:
       hugepages-2Mi: 1Gi # Requires sysctl set on the host
       memory: 1Gi

--- a/kubernetes/apps/flux-system/konflate/app/helmrelease.yaml
+++ b/kubernetes/apps/flux-system/konflate/app/helmrelease.yaml
@@ -35,5 +35,6 @@ spec:
     resources:
       requests:
         cpu: 50m
+        memory: 512Mi
       limits:
         memory: 1Gi

--- a/kubernetes/apps/kopiur-system/kopiur/app/helmrelease.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/app/helmrelease.yaml
@@ -43,5 +43,6 @@ spec:
     resources:
       requests:
         cpu: 100m
+        memory: 256Mi
       limits:
-        memory: 2Gi
+        memory: 512Mi

--- a/kubernetes/apps/media/audiobookshelf/app/helmrelease.yaml
+++ b/kubernetes/apps/media/audiobookshelf/app/helmrelease.yaml
@@ -50,7 +50,8 @@ spec:
                   periodSeconds: 10
             resources:
               requests:
-                cpu: 10m
+                cpu: 50m
+                memory: 256Mi
               limits:
                 memory: 1Gi
     defaultPodOptions:

--- a/kubernetes/apps/media/autobrr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/autobrr/app/helmrelease.yaml
@@ -59,6 +59,7 @@ spec:
             resources:
               requests:
                 cpu: 10m
+                memory: 384Mi
               limits:
                 memory: 512Mi
     defaultPodOptions:

--- a/kubernetes/apps/media/jellyfin/app/helmrelease.yaml
+++ b/kubernetes/apps/media/jellyfin/app/helmrelease.yaml
@@ -51,7 +51,8 @@ spec:
               claims:
                 - name: gpu
               requests:
-                cpu: 100m
+                cpu: 500m
+                memory: 2Gi
               limits:
                 memory: 4Gi
     defaultPodOptions:

--- a/kubernetes/apps/media/prowlarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/prowlarr/app/helmrelease.yaml
@@ -60,9 +60,10 @@ spec:
               capabilities: { drop: ["ALL"] }
             resources:
               requests:
-                cpu: 10m
+                cpu: 25m
+                memory: 192Mi
               limits:
-                memory: 1Gi
+                memory: 512Mi
     defaultPodOptions:
       securityContext:
         runAsNonRoot: true

--- a/kubernetes/apps/media/qbittorrent/app/helmrelease.yaml
+++ b/kubernetes/apps/media/qbittorrent/app/helmrelease.yaml
@@ -49,7 +49,8 @@ spec:
               capabilities: { drop: ["ALL"] }
             resources:
               requests:
-                cpu: 100m
+                cpu: 250m
+                memory: 2Gi
               limits:
                 memory: 4Gi
     defaultPodOptions:

--- a/kubernetes/apps/media/qui/app/helmrelease.yaml
+++ b/kubernetes/apps/media/qui/app/helmrelease.yaml
@@ -57,8 +57,9 @@ spec:
             resources:
               requests:
                 cpu: 10m
+                memory: 64Mi
               limits:
-                memory: 1Gi
+                memory: 256Mi
             securityContext:
               allowPrivilegeEscalation: false
               readOnlyRootFilesystem: true

--- a/kubernetes/apps/media/radarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/radarr/app/helmrelease.yaml
@@ -61,6 +61,7 @@ spec:
             resources:
               requests:
                 cpu: 100m
+                memory: 384Mi
               limits:
                 memory: 1Gi
     defaultPodOptions:

--- a/kubernetes/apps/media/readmeabook/app/helmrelease.yaml
+++ b/kubernetes/apps/media/readmeabook/app/helmrelease.yaml
@@ -58,9 +58,10 @@ spec:
                   periodSeconds: 10
             resources:
               requests:
-                cpu: 10m
+                cpu: 150m
+                memory: 384Mi
               limits:
-                memory: 512Mi
+                memory: 768Mi
     service:
       app:
         ports:

--- a/kubernetes/apps/media/recyclarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/recyclarr/app/helmrelease.yaml
@@ -39,6 +39,7 @@ spec:
             resources:
               requests:
                 cpu: 10m
+                memory: 64Mi
               limits:
                 memory: 128Mi
         pod:

--- a/kubernetes/apps/media/seerr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/seerr/app/helmrelease.yaml
@@ -55,6 +55,7 @@ spec:
             resources:
               requests:
                 cpu: 50m
+                memory: 384Mi
               limits:
                 memory: 1Gi
     defaultPodOptions:

--- a/kubernetes/apps/media/sonarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/sonarr/app/helmrelease.yaml
@@ -61,6 +61,7 @@ spec:
             resources:
               requests:
                 cpu: 100m
+                memory: 384Mi
               limits:
                 memory: 1Gi
     defaultPodOptions:

--- a/kubernetes/apps/media/yubal/app/helmrelease.yaml
+++ b/kubernetes/apps/media/yubal/app/helmrelease.yaml
@@ -37,7 +37,8 @@ spec:
               readiness: *probes
             resources:
               requests:
-                cpu: 10m
+                cpu: 25m
+                memory: 128Mi
               limits:
                 memory: 512Mi
             securityContext:

--- a/kubernetes/apps/network/cloudflare-tunnel/app/helmrelease.yaml
+++ b/kubernetes/apps/network/cloudflare-tunnel/app/helmrelease.yaml
@@ -50,8 +50,9 @@ spec:
             resources:
               requests:
                 cpu: 10m
+                memory: 64Mi
               limits:
-                memory: 256Mi
+                memory: 128Mi
     defaultPodOptions:
       securityContext:
         runAsNonRoot: true

--- a/kubernetes/apps/network/envoy-gateway/app/envoy.yaml
+++ b/kubernetes/apps/network/envoy-gateway/app/envoy.yaml
@@ -19,8 +19,9 @@ spec:
           resources:
             requests:
               cpu: 100m
+              memory: 256Mi
             limits:
-              memory: 2Gi
+              memory: 512Mi
       envoyService:
         externalTrafficPolicy: Local
   shutdown:

--- a/kubernetes/apps/observability/gatus-sidecar/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/gatus-sidecar/app/helmrelease.yaml
@@ -48,6 +48,7 @@ spec:
       size: 5Gi
     resources:
       requests:
-        cpu: 100m
+        cpu: 50m
+        memory: 128Mi
       limits:
-        memory: 512Mi
+        memory: 256Mi

--- a/kubernetes/apps/observability/kromgo/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/kromgo/app/helmrelease.yaml
@@ -83,5 +83,6 @@ spec:
     resources:
       requests:
         cpu: 10m
+        memory: 48Mi
       limits:
-        memory: 64Mi
+        memory: 96Mi

--- a/kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml
@@ -61,9 +61,10 @@ spec:
         retentionSize: 40GiB
         resources:
           requests:
-            cpu: 100m
+            cpu: 200m
+            memory: 2Gi
           limits:
-            memory: 2000Mi
+            memory: 3Gi
         storageSpec:
           volumeClaimTemplate:
             spec:

--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -33,10 +33,10 @@ spec:
       resources:
         mgr:
           limits:
-            memory: 1Gi
+            memory: 2Gi
           requests:
             cpu: 100m
-            memory: 512Mi
+            memory: 1Gi
         mon:
           limits:
             memory: 2Gi
@@ -48,6 +48,7 @@ spec:
             memory: 8Gi # Required for bootstrap
           requests:
             cpu: 500m
+            memory: 4Gi
       storage:
         devicePathFilter: /dev/disk/by-id/nvme-*
         useAllDevices: false

--- a/kubernetes/apps/selfhosted/actual/app/helmrelease.yaml
+++ b/kubernetes/apps/selfhosted/actual/app/helmrelease.yaml
@@ -22,8 +22,9 @@ spec:
             resources:
               requests:
                 cpu: 10m
+                memory: 128Mi
               limits:
-                memory: 512Mi
+                memory: 256Mi
     defaultPodOptions:
       securityContext:
         runAsUser: 1000

--- a/kubernetes/apps/selfhosted/atuin/app/helmrelease.yaml
+++ b/kubernetes/apps/selfhosted/atuin/app/helmrelease.yaml
@@ -54,8 +54,9 @@ spec:
             resources:
               requests:
                 cpu: 10m
+                memory: 64Mi
               limits:
-                memory: 256Mi
+                memory: 128Mi
     defaultPodOptions:
       securityContext:
         runAsNonRoot: true

--- a/kubernetes/apps/selfhosted/donetick/app/helmrelease.yaml
+++ b/kubernetes/apps/selfhosted/donetick/app/helmrelease.yaml
@@ -54,8 +54,9 @@ spec:
             resources:
               requests:
                 cpu: 10m
+                memory: 64Mi
               limits:
-                memory: 512Mi
+                memory: 256Mi
             securityContext:
               allowPrivilegeEscalation: false
               readOnlyRootFilesystem: true

--- a/kubernetes/apps/selfhosted/executor/app/helmrelease.yaml
+++ b/kubernetes/apps/selfhosted/executor/app/helmrelease.yaml
@@ -41,9 +41,10 @@ spec:
               capabilities: { drop: ["ALL"] }
             resources:
               requests:
-                cpu: 10m
+                cpu: 50m
+                memory: 512Mi
               limits:
-                memory: 1Gi
+                memory: 2Gi
     defaultPodOptions:
       securityContext:
         runAsNonRoot: true

--- a/kubernetes/apps/selfhosted/home-assistant/app/helmrelease.yaml
+++ b/kubernetes/apps/selfhosted/home-assistant/app/helmrelease.yaml
@@ -31,7 +31,8 @@ spec:
               capabilities: { drop: ["ALL"] }
             resources:
               requests:
-                cpu: 10m
+                cpu: 50m
+                memory: 512Mi
               limits:
                 memory: 1Gi
     defaultPodOptions:

--- a/kubernetes/apps/selfhosted/immich/app/helmrelease.yaml
+++ b/kubernetes/apps/selfhosted/immich/app/helmrelease.yaml
@@ -41,6 +41,7 @@ spec:
             resources:
               requests:
                 cpu: 100m
+                memory: 1536Mi
               limits:
                 memory: 3Gi
       machine-learning:
@@ -60,6 +61,7 @@ spec:
             resources:
               requests:
                 cpu: 100m
+                memory: 768Mi
               limits:
                 memory: 4Gi
     defaultPodOptions:

--- a/kubernetes/apps/selfhosted/it-tools/app/helmrelease.yaml
+++ b/kubernetes/apps/selfhosted/it-tools/app/helmrelease.yaml
@@ -28,7 +28,7 @@ spec:
                 cpu: 5m
                 memory: 32Mi
               limits:
-                memory: 256Mi
+                memory: 128Mi
     defaultPodOptions:
       securityContext:
         runAsNonRoot: true

--- a/kubernetes/apps/selfhosted/karakeep/app/helmrelease.yaml
+++ b/kubernetes/apps/selfhosted/karakeep/app/helmrelease.yaml
@@ -46,9 +46,10 @@ spec:
                 enabled: true
             resources:
               requests:
-                cpu: 10m
-              limits:
+                cpu: 25m
                 memory: 1Gi
+              limits:
+                memory: 1536Mi
       meilisearch:
         annotations:
           reloader.stakater.com/auto: "true"
@@ -85,8 +86,9 @@ spec:
             resources:
               requests:
                 cpu: 10m
+                memory: 256Mi
               limits:
-                memory: 2Gi
+                memory: 1Gi
       chrome:
         annotations:
           reloader.stakater.com/auto: "true"
@@ -112,8 +114,9 @@ spec:
             resources:
               requests:
                 cpu: 10m
+                memory: 256Mi
               limits:
-                memory: 2Gi
+                memory: 768Mi
     defaultPodOptions:
       securityContext:
         runAsUser: 1000

--- a/kubernetes/apps/selfhosted/paperless-ai/app/helmrelease.yaml
+++ b/kubernetes/apps/selfhosted/paperless-ai/app/helmrelease.yaml
@@ -24,9 +24,10 @@ spec:
                   name: "{{ .Release.Name }}-secret"
             resources:
               requests:
-                cpu: 10m
-              limits:
+                cpu: 50m
                 memory: 2Gi
+              limits:
+                memory: 3Gi
     service:
       app:
         ports:

--- a/kubernetes/apps/selfhosted/paperless/app/helmrelease.yaml
+++ b/kubernetes/apps/selfhosted/paperless/app/helmrelease.yaml
@@ -79,6 +79,7 @@ spec:
             resources:
               requests:
                 cpu: 100m
+                memory: 1536Mi
               limits:
                 memory: 2Gi
     service:

--- a/kubernetes/apps/selfhosted/pocket-id/app/helmrelease.yaml
+++ b/kubernetes/apps/selfhosted/pocket-id/app/helmrelease.yaml
@@ -51,8 +51,9 @@ spec:
             resources:
               requests:
                 cpu: 10m
+                memory: 64Mi
               limits:
-                memory: 512Mi
+                memory: 256Mi
             securityContext:
               allowPrivilegeEscalation: false
               readOnlyRootFilesystem: true

--- a/kubernetes/apps/selfhosted/yarr/app/helmrelease.yaml
+++ b/kubernetes/apps/selfhosted/yarr/app/helmrelease.yaml
@@ -25,8 +25,9 @@ spec:
             resources:
               requests:
                 cpu: 10m
+                memory: 32Mi
               limits:
-                memory: 512Mi
+                memory: 128Mi
             securityContext:
               allowPrivilegeEscalation: false
               readOnlyRootFilesystem: true


### PR DESCRIPTION
## Summary

- add explicit memory requests to avoid memory limits implicitly becoming scheduler requests
- increase headroom for workloads observed near their memory ceilings and reduce clear over-reservations
- adjust selected CPU requests using 30-day usage data while retaining the no-CPU-limit policy


## Validation

- parsed every changed YAML document with `yq`
- built every affected Kustomize directory
- ran `git diff --check`
- verified no CPU limits were added
- passed the repository `format-yaml` pre-commit hook
