### PR TITLE
Improve Karakeep AI and deployment settings

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -11,6 +11,12 @@
     },
   ],
   packageRules: [
+    {
+      description: "Pin Meilisearch to the Karakeep-validated deployment version",
+      matchDatasources: ["docker"],
+      matchPackageNames: ["getmeili/meilisearch"],
+      enabled: false,
+    },
     // Auto-merge rules
     {
       description: "Auto-merge trusted OCI digests",

--- a/kubernetes/apps/selfhosted/karakeep/app/helmrelease.yaml
+++ b/kubernetes/apps/selfhosted/karakeep/app/helmrelease.yaml
@@ -21,18 +21,32 @@ spec:
               tag: 0.33.1@sha256:5467873df817ab3aa837f2b06bd7f2b0974132ba1ae5bce0b7e2fd134abc269b
             env:
               DATA_DIR: /data
+              DB_WAL_MODE: true
               MEILI_ADDR: http://karakeep-meilisearch:7700
               BROWSER_WEB_URL: http://karakeep-chrome:9222
               NEXTAUTH_URL: https://karakeep.rodent.cc
+              # AI and semantic search
+              INFERENCE_TEXT_MODEL: gpt-5.6-luna
+              INFERENCE_IMAGE_MODEL: gpt-4o-mini
+              INFERENCE_CONTEXT_LENGTH: 4096
+              INFERENCE_ENABLE_AUTO_SUMMARIZATION: true
+              EMBEDDING_TEXT_MODEL: text-embedding-3-small
+              EMBEDDING_DIMENSIONS: 1536
+              EMBEDDING_ENABLE_AUTO_INDEXING: true
+              SEMANTIC_SEARCH_ENABLED: true
               CRAWLER_DOWNLOAD_BANNER_IMAGE: true
               CRAWLER_ENABLE_ADBLOCKER: true
               CRAWLER_STORE_SCREENSHOT: true
               CRAWLER_FULL_PAGE_ARCHIVE: true
-              CRAWLER_FULL_PAGE_SCREENSHOT: true
+              CRAWLER_FULL_PAGE_SCREENSHOT: false
+              CRAWLER_STORE_PDF: false
               CRAWLER_VIDEO_DOWNLOAD: true
               # OAuth setup
+              DISABLE_SIGNUPS: true
               DISABLE_PASSWORD_AUTH: true
               DISABLE_NEW_RELEASE_CHECK: true
+              RATE_LIMITING_ENABLED: true
+              OAUTH_AUTO_REDIRECT: true
               OAUTH_ALLOW_DANGEROUS_EMAIL_ACCOUNT_LINKING: true
               OAUTH_PROVIDER_NAME: Pocket-ID
               COREPACK_INTEGRITY_KEYS: 0


### PR DESCRIPTION
## What changed

- explicitly configure Karakeep's OpenAI inference, embeddings, semantic search, and automatic summarization
- increase inference context to 4096 tokens
- enable SQLite WAL mode, API rate limiting, disable new signups, and auto-redirect OAuth logins
- retain full-page HTML archives while switching screenshots from full-page to viewport captures and leaving PDF capture disabled
- pin the currently healthy Meilisearch 1.50.0 deployment by disabling Renovate updates for `getmeili/meilisearch`

## Why

Karakeep 0.33.1 introduced semantic search and embedding-assisted tagging, but the existing library still needs embeddings generated and the deployment relied on mutable AI defaults. Meilisearch has an on-disk format that makes automatic version changes risky; the previous 1.51 update had already needed to be reverted.

## Impact

After rollout, new bookmarks will be embedded and summarized automatically. Existing bookmarks are unchanged until the embeddings background job is run. Existing stored full-page screenshots and other assets are not deleted by this configuration change.

## Validation

- `git diff --check`
- YAML parse with `yq`
- complete `kubectl kustomize kubernetes/apps/selfhosted/karakeep/app` render
- repository pre-commit hooks: JSON and YAML formatting
