### PR TITLE
Increase memory headroom for Karakeep and Prometheus

### DIFF
--- a/kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml
@@ -64,7 +64,7 @@ spec:
             cpu: 200m
             memory: 2Gi
           limits:
-            memory: 3Gi
+            memory: 4Gi
         storageSpec:
           volumeClaimTemplate:
             spec:

--- a/kubernetes/apps/selfhosted/karakeep/app/helmrelease.yaml
+++ b/kubernetes/apps/selfhosted/karakeep/app/helmrelease.yaml
@@ -64,7 +64,7 @@ spec:
                 cpu: 25m
                 memory: 1Gi
               limits:
-                memory: 1536Mi
+                memory: 2Gi
       meilisearch:
         annotations:
           reloader.stakater.com/auto: "true"
@@ -131,7 +131,7 @@ spec:
                 cpu: 10m
                 memory: 256Mi
               limits:
-                memory: 768Mi
+                memory: 1Gi
     defaultPodOptions:
       securityContext:
         runAsUser: 1000


### PR DESCRIPTION
## Summary

- increase Karakeep memory limit from 1536Mi to 2Gi
- increase Karakeep Chrome memory limit from 768Mi to 1Gi
- increase Prometheus memory limit from 3Gi to 4Gi
- keep existing CPU and memory requests unchanged

## Why

The post-deployment review found that the previous Karakeep pod restarted seven times with OOMKilled as its last termination reason, while Karakeep Chrome was OOM-killed once. Prometheus reached roughly 90% of its 3Gi memory limit during the three-day observation window.

These focused increases restore conservative burst and restart headroom without changing scheduling reservations or introducing CPU limits.

## Validation

- `git diff --check`
- YAML pre-commit formatter
- rendered the `selfhosted/karakeep` Flux Kustomization with Flate
- rendered the `observability/kube-prometheus-stack` Flux Kustomization with Flate
- parsed both rendered outputs with yq
