### PR TITLE
fix(flux): avoid duplicate kustomize concurrency flags

### DIFF
--- a/kubernetes/apps/flux-system/flux-instance/app/helmrelease.yaml
+++ b/kubernetes/apps/flux-system/flux-instance/app/helmrelease.yaml
@@ -38,7 +38,7 @@ spec:
                 value: --requeue-dependency=5s
             target:
               kind: Deployment
-              name: (kustomize-controller|helm-controller|source-controller)
+              name: (helm-controller|source-controller)
           - # Increase the memory limits
             patch: |-
               apiVersion: apps/v1
@@ -61,6 +61,9 @@ spec:
               - op: add
                 path: /spec/template/spec/containers/0/args/-
                 value: --concurrent=20
+              - op: add
+                path: /spec/template/spec/containers/0/args/-
+                value: --requeue-dependency=5s
               - op: replace
                 path: /spec/template/spec/volumes/0
                 value:


### PR DESCRIPTION
## Summary

- restrict the 10-worker patch to helm-controller and source-controller
- keep kustomize-controller at 20 workers
- apply requeue-dependency exactly once to each controller

This prevents kustomize-controller from receiving conflicting concurrent=10 and concurrent=20 arguments.

## Validation

- rendered Flux HelmReleases with Flate 0.6.1
- pre-commit YAML formatting passed
- git diff --check passed