### PR TITLE
fix(sonarr): configure allowed hosts and trusted network

### DIFF
--- a/kubernetes/apps/media/sonarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/sonarr/app/helmrelease.yaml
@@ -26,7 +26,9 @@ spec:
               SONARR__AUTH__REQUIRED: DisabledForLocalAddresses
               SONARR__LOG__DBENABLED: "False"
               SONARR__LOG__LEVEL: info
+              SONARR__SERVER__ALLOWEDHOSTS: sonarr.rodent.cc,sonarr.media.svc.cluster.local
               SONARR__SERVER__PORT: &port 80
+              SONARR__SERVER__TRUSTEDNETWORKS: 10.42.0.0/16
               SONARR__UPDATE__BRANCH: develop
               TZ: Europe/Oslo
             envFrom:
@@ -46,6 +48,9 @@ spec:
                   httpGet:
                     path: /ping
                     port: *port
+                    httpHeaders:
+                      - name: Host
+                        value: localhost
                   periodSeconds: 10
                   timeoutSeconds: 5
                   failureThreshold: 5


### PR DESCRIPTION
## Summary

- allow sonarr.rodent.cc and sonarr.media.svc.cluster.local
- trust the 10.42.0.0/16 pod network for forwarded client addresses
- send Host: localhost from the readiness probe

This aligns Sonarr 4.0.19.3006+ host validation with the existing External authentication and DisabledForLocalAddresses configuration.

## Validation

- rendered the Sonarr HelmRelease with Flate 0.6.1
- pre-commit YAML formatting passed
- git diff --check passed