### PR TITLE
refactor(flux): decouple apps from Ceph health

### DIFF
--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/ks.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/ks.yaml
@@ -23,8 +23,6 @@ metadata:
 spec:
   dependsOn:
     - name: actions-runner-controller
-    - name: rook-ceph-cluster
-      namespace: rook-ceph
   interval: 1h
   path: ./kubernetes/apps/actions-runner-system/actions-runner-controller/runners
   prune: true

--- a/kubernetes/apps/media/audiobookshelf/ks.yaml
+++ b/kubernetes/apps/media/audiobookshelf/ks.yaml
@@ -8,9 +8,6 @@ spec:
   components:
     - ../../../../components/kopiur
     - ../../../../components/zeroscaler
-  dependsOn:
-    - name: rook-ceph-cluster
-      namespace: rook-ceph
   interval: 1h
   path: ./kubernetes/apps/media/audiobookshelf/app
   postBuild:

--- a/kubernetes/apps/media/autobrr/ks.yaml
+++ b/kubernetes/apps/media/autobrr/ks.yaml
@@ -7,9 +7,6 @@ metadata:
 spec:
   components:
     - ../../../../components/kopiur
-  dependsOn:
-    - name: rook-ceph-cluster
-      namespace: rook-ceph
   interval: 1h
   path: ./kubernetes/apps/media/autobrr/app
   postBuild:

--- a/kubernetes/apps/media/jellyfin/ks.yaml
+++ b/kubernetes/apps/media/jellyfin/ks.yaml
@@ -11,8 +11,6 @@ spec:
   dependsOn:
     - name: intel-gpu-resource-driver
       namespace: kube-system
-    - name: rook-ceph-cluster
-      namespace: rook-ceph
   interval: 1h
   path: ./kubernetes/apps/media/jellyfin/app
   postBuild:

--- a/kubernetes/apps/media/prowlarr/ks.yaml
+++ b/kubernetes/apps/media/prowlarr/ks.yaml
@@ -7,9 +7,6 @@ metadata:
 spec:
   components:
     - ../../../../components/kopiur
-  dependsOn:
-    - name: rook-ceph-cluster
-      namespace: rook-ceph
   interval: 1h
   path: ./kubernetes/apps/media/prowlarr/app
   postBuild:

--- a/kubernetes/apps/media/qbittorrent/ks.yaml
+++ b/kubernetes/apps/media/qbittorrent/ks.yaml
@@ -8,9 +8,6 @@ spec:
   components:
     - ../../../../components/kopiur
     - ../../../../components/zeroscaler
-  dependsOn:
-    - name: rook-ceph-cluster
-      namespace: rook-ceph
   interval: 1h
   path: ./kubernetes/apps/media/qbittorrent/app
   postBuild:

--- a/kubernetes/apps/media/qui/ks.yaml
+++ b/kubernetes/apps/media/qui/ks.yaml
@@ -8,9 +8,6 @@ spec:
   components:
     - ../../../../components/kopiur
     - ../../../../components/zeroscaler
-  dependsOn:
-    - name: rook-ceph-cluster
-      namespace: rook-ceph
   interval: 1h
   path: ./kubernetes/apps/media/qui/app
   postBuild:

--- a/kubernetes/apps/media/radarr/ks.yaml
+++ b/kubernetes/apps/media/radarr/ks.yaml
@@ -8,9 +8,6 @@ spec:
   components:
     - ../../../../components/kopiur
     - ../../../../components/zeroscaler
-  dependsOn:
-    - name: rook-ceph-cluster
-      namespace: rook-ceph
   interval: 1h
   path: ./kubernetes/apps/media/radarr/app
   postBuild:

--- a/kubernetes/apps/media/readmeabook/ks.yaml
+++ b/kubernetes/apps/media/readmeabook/ks.yaml
@@ -13,8 +13,6 @@ spec:
       namespace: database
     - name: dragonfly-cluster
       namespace: database
-    - name: rook-ceph-cluster
-      namespace: rook-ceph
   interval: 1h
   path: ./kubernetes/apps/media/readmeabook/app
   postBuild:

--- a/kubernetes/apps/media/recyclarr/ks.yaml
+++ b/kubernetes/apps/media/recyclarr/ks.yaml
@@ -7,9 +7,6 @@ metadata:
 spec:
   components:
     - ../../../../components/kopiur
-  dependsOn:
-    - name: rook-ceph-cluster
-      namespace: rook-ceph
   interval: 1h
   path: ./kubernetes/apps/media/recyclarr/app
   postBuild:

--- a/kubernetes/apps/media/seerr/ks.yaml
+++ b/kubernetes/apps/media/seerr/ks.yaml
@@ -7,9 +7,6 @@ metadata:
 spec:
   components:
     - ../../../../components/kopiur
-  dependsOn:
-    - name: rook-ceph-cluster
-      namespace: rook-ceph
   interval: 1h
   path: ./kubernetes/apps/media/seerr/app
   postBuild:

--- a/kubernetes/apps/media/sonarr/ks.yaml
+++ b/kubernetes/apps/media/sonarr/ks.yaml
@@ -8,9 +8,6 @@ spec:
   components:
     - ../../../../components/kopiur
     - ../../../../components/zeroscaler
-  dependsOn:
-    - name: rook-ceph-cluster
-      namespace: rook-ceph
   interval: 1h
   path: ./kubernetes/apps/media/sonarr/app
   postBuild:

--- a/kubernetes/apps/media/yubal/ks.yaml
+++ b/kubernetes/apps/media/yubal/ks.yaml
@@ -8,9 +8,6 @@ spec:
   components:
     - ../../../../components/kopiur
     - ../../../../components/zeroscaler
-  dependsOn:
-    - name: rook-ceph-cluster
-      namespace: rook-ceph
   interval: 1h
   path: ./kubernetes/apps/media/yubal/app
   postBuild:

--- a/kubernetes/apps/observability/grafana/ks.yaml
+++ b/kubernetes/apps/observability/grafana/ks.yaml
@@ -23,8 +23,6 @@ metadata:
 spec:
   dependsOn:
     - name: grafana
-    - name: rook-ceph-cluster
-      namespace: rook-ceph
   interval: 1h
   path: ./kubernetes/apps/observability/grafana/instance
   prune: true

--- a/kubernetes/apps/observability/kube-prometheus-stack/ks.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/ks.yaml
@@ -5,9 +5,6 @@ kind: Kustomization
 metadata:
   name: kube-prometheus-stack
 spec:
-  dependsOn:
-    - name: rook-ceph-cluster
-      namespace: rook-ceph
   interval: 1h
   path: ./kubernetes/apps/observability/kube-prometheus-stack/app
   prune: true

--- a/kubernetes/apps/observability/victoria-logs/ks.yaml
+++ b/kubernetes/apps/observability/victoria-logs/ks.yaml
@@ -5,9 +5,6 @@ kind: Kustomization
 metadata:
   name: victoria-logs
 spec:
-  dependsOn:
-    - name: rook-ceph-cluster
-      namespace: rook-ceph
   interval: 1h
   path: ./kubernetes/apps/observability/victoria-logs/app
   prune: true

--- a/kubernetes/apps/selfhosted/actual/ks.yaml
+++ b/kubernetes/apps/selfhosted/actual/ks.yaml
@@ -7,9 +7,6 @@ metadata:
 spec:
   components:
     - ../../../../components/kopiur
-  dependsOn:
-    - name: rook-ceph-cluster
-      namespace: rook-ceph
   interval: 1h
   path: ./kubernetes/apps/selfhosted/actual/app
   postBuild:

--- a/kubernetes/apps/selfhosted/atuin/ks.yaml
+++ b/kubernetes/apps/selfhosted/atuin/ks.yaml
@@ -7,9 +7,6 @@ metadata:
 spec:
   components:
     - ../../../../components/kopiur
-  dependsOn:
-    - name: rook-ceph-cluster
-      namespace: rook-ceph
   interval: 1h
   path: ./kubernetes/apps/selfhosted/atuin/app
   postBuild:

--- a/kubernetes/apps/selfhosted/donetick/ks.yaml
+++ b/kubernetes/apps/selfhosted/donetick/ks.yaml
@@ -7,9 +7,6 @@ metadata:
 spec:
   components:
     - ../../../../components/kopiur
-  dependsOn:
-    - name: rook-ceph-cluster
-      namespace: rook-ceph
   interval: 1h
   path: ./kubernetes/apps/selfhosted/donetick/app
   postBuild:

--- a/kubernetes/apps/selfhosted/executor/ks.yaml
+++ b/kubernetes/apps/selfhosted/executor/ks.yaml
@@ -7,9 +7,6 @@ metadata:
 spec:
   components:
     - ../../../../components/kopiur
-  dependsOn:
-    - name: rook-ceph-cluster
-      namespace: rook-ceph
   interval: 1h
   path: ./kubernetes/apps/selfhosted/executor/app
   postBuild:

--- a/kubernetes/apps/selfhosted/home-assistant/ks.yaml
+++ b/kubernetes/apps/selfhosted/home-assistant/ks.yaml
@@ -7,9 +7,6 @@ metadata:
 spec:
   components:
     - ../../../../components/kopiur
-  dependsOn:
-    - name: rook-ceph-cluster
-      namespace: rook-ceph
   interval: 1h
   path: ./kubernetes/apps/selfhosted/home-assistant/app
   postBuild:

--- a/kubernetes/apps/selfhosted/karakeep/ks.yaml
+++ b/kubernetes/apps/selfhosted/karakeep/ks.yaml
@@ -7,9 +7,6 @@ metadata:
 spec:
   components:
     - ../../../../components/kopiur
-  dependsOn:
-    - name: rook-ceph-cluster
-      namespace: rook-ceph
   interval: 1h
   path: ./kubernetes/apps/selfhosted/karakeep/app
   postBuild:

--- a/kubernetes/apps/selfhosted/paperless-ai/ks.yaml
+++ b/kubernetes/apps/selfhosted/paperless-ai/ks.yaml
@@ -7,9 +7,6 @@ metadata:
 spec:
   components:
     - ../../../../components/kopiur
-  dependsOn:
-    - name: rook-ceph-cluster
-      namespace: rook-ceph
   interval: 1h
   path: ./kubernetes/apps/selfhosted/paperless-ai/app
   postBuild:

--- a/kubernetes/apps/selfhosted/paperless/ks.yaml
+++ b/kubernetes/apps/selfhosted/paperless/ks.yaml
@@ -10,8 +10,6 @@ spec:
   dependsOn:
     - name: dragonfly-cluster
       namespace: database
-    - name: rook-ceph-cluster
-      namespace: rook-ceph
   interval: 1h
   path: ./kubernetes/apps/selfhosted/paperless/app
   postBuild:

--- a/kubernetes/apps/selfhosted/pocket-id/ks.yaml
+++ b/kubernetes/apps/selfhosted/pocket-id/ks.yaml
@@ -7,9 +7,6 @@ metadata:
 spec:
   components:
     - ../../../../components/kopiur
-  dependsOn:
-    - name: rook-ceph-cluster
-      namespace: rook-ceph
   interval: 1h
   path: ./kubernetes/apps/selfhosted/pocket-id/app
   postBuild:

--- a/kubernetes/apps/selfhosted/yarr/ks.yaml
+++ b/kubernetes/apps/selfhosted/yarr/ks.yaml
@@ -7,9 +7,6 @@ metadata:
 spec:
   components:
     - ../../../../components/kopiur
-  dependsOn:
-    - name: rook-ceph-cluster
-      namespace: rook-ceph
   interval: 1h
   path: ./kubernetes/apps/selfhosted/yarr/app
   postBuild:


### PR DESCRIPTION
## Summary

- remove rook-ceph-cluster availability dependencies from 26 application Kustomizations
- preserve controller, database, GPU, and other apply-time dependencies
- rely on Kubernetes to keep PVC-backed workloads pending until storage is available

Kopiur and snapshot CRDs are already installed during bootstrap, so a Ceph HEALTH_ERR no longer needs to block unrelated application reconciliation.

## Validation

- built the actions-runner-system, media, observability, and selfhosted trees with Kustomize
- parsed every changed YAML file with yq
- pre-commit YAML formatting passed
- git diff --check passed

A full Flate graph render still requires private ocharted.rodent.cc registry credentials; failures were limited to those existing private chart sources.