### PR TITLE
feat(talos): update to v1.14.0-rc.2

### DIFF
--- a/kubernetes/apps/system-upgrade/tuppr/upgrades/talosupgrade.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/upgrades/talosupgrade.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   talos:
     # renovate: datasource=custom.talos-factory depName=siderolabs/talos
-    version: v1.14.0-rc.1
+    version: v1.14.0-rc.2
   policy:
     rebootMode: powercycle
   healthChecks:

--- a/talos/cluster.yaml.j2
+++ b/talos/cluster.yaml.j2
@@ -52,7 +52,7 @@ clusterSecret: op://home-ops/talos/CLUSTER_SECRET
 apiVersion: v1alpha1
 kind: UnattendedInstallConfig
 installer:
-  image: factory.talos.dev/metal-installer/{{ schematic }}:v1.14.0-rc.1
+  image: factory.talos.dev/metal-installer/{{ schematic }}:v1.14.0-rc.2
 provisioning:
   wipe: false
 ---


### PR DESCRIPTION
## Summary

- update the unattended installer image from Talos v1.14.0-rc.1 to rc.2
- update the Tuppr TalosUpgrade target to the same version

## Validation

- rendered the Talos cluster template with Minijinja
- parsed the rendered machine configuration and TalosUpgrade YAML with yq
- pre-commit YAML formatting passed
- git diff --check passed